### PR TITLE
The stale view parameter should not be json encoded when passed.

### DIFF
--- a/couch/couch.py
+++ b/couch/couch.py
@@ -390,7 +390,7 @@ class AsyncCouch(object):
                     body.update({'keys': value})
                 else:
                     value = url_escape(
-                        value if key in ('startkey_docid', 'endkey_docid')
+                        value if key in ('startkey_docid', 'endkey_docid', 'stale')
                         else json_encode(value))
                     options.append('='.join([key, value]))
         if options:


### PR DESCRIPTION
At least not in couchdb 2.1, where I need this fix for.